### PR TITLE
Removing battery cell type since it is no longer used

### DIFF
--- a/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
+++ b/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
@@ -237,17 +237,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "In the battery subsystem, the type of battery cell we use is `18650`. The option is not set in `input_file`. So, let us set it to `18650`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a3d9e536",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prob.aviary_inputs.set_val(Aircraft.Battery.CELL_TYPE, \"18650\")"
+    "In the battery subsystem, the type of battery cell we use is `18650`. The option is not set in `input_file`, instead is is controlled by importing the correct battery map [here](https://github.com/OpenMDAO/om-Aviary/blob/1fca1c03cb2e1d6387442162e8d7dabf83eee197/aviary/examples/external_subsystems/battery/model/reg_thevenin_interp_group.py#L5)."
    ]
   },
   {

--- a/aviary/docs/user_guide/battery_subsystem_example.md
+++ b/aviary/docs/user_guide/battery_subsystem_example.md
@@ -151,8 +151,6 @@ def build_mission(self, num_nodes, aviary_inputs):
 
 Note that `build_mission` requires both `num_nodes` and `aviary_inputs` as arguments.
 `num_nodes` is needed to correctly set up all the vectors within your mission subsystem, whereas `aviary_inputs` helps provide necessary options for the subsystem.
-For example, in our battery case `aviary_inputs` contains `Aircraft.Battery.CELL_TYPE`, which naturally details which battery type to use.
-This allows the mission subsystem to use different battery performance maps based on what the user specifies.
 
 ## Defining helper methods, like preprocessing, initial guessing, and linking
 
@@ -169,29 +167,6 @@ For both users and developers: `preprocess_inputs` happens **once** per analysis
 ```
 
 You can have calculations or checks you need in this method based on user inputs.
-For the battery example, based on which cell type the user selects we want to prepopulate the `aviary_inputs` object differently, like this:
-
-```python
-def preprocess_inputs(self, aviary_inputs):
-    battery_cell_types = {
-        "18650": {
-            Aircraft.Battery.Cell.DISCHARGE_RATE: [10.5, 'A'],
-            Aircraft.Battery.Cell.ENERGY_CAPACITY_MAX: [3.5, 'A*h'],
-            Aircraft.Battery.Cell.HEAT_CAPACITY: [1020.0, 'J/(kg*K)'],
-            Aircraft.Battery.Cell.MASS: [0.045, 'kg'],
-            Aircraft.Battery.Cell.VOLTAGE_LOW: [2.9, 'V'],
-            Aircraft.Battery.Cell.VOLUME: [1.125, 'inch**3']
-        }
-    }
-
-    battery_info = battery_cell_types[aviary_inputs.get_val(
-        Aircraft.Battery.CELL_TYPE)]
-
-    for key, val in battery_info.items():
-        aviary_inputs.set_val(key, val[0], units=val[1], meta_data=ExtendedMetaData)
-
-    return aviary_inputs
-```
 
 Now you may want to link some variables between phases.
 States, for example, are usually great candidates for linking.
@@ -267,7 +242,6 @@ class TestBattery(av.TestSubsystemBuilderBase):
     def setUp(self):
         self.subsystem_builder = BatteryBuilder()
         self.aviary_inputs = av.AviaryValues()
-        self.aviary_inputs.set_val(Aircraft.Battery.CELL_TYPE, '18650')
 ```
 
 For instance, if you saved this class in a file called `test_battery.py`, you could then run `testflo test_battery.py` to verify that all the methods do what Aviary expects.

--- a/aviary/examples/external_subsystems/battery/battery_variable_meta_data.py
+++ b/aviary/examples/external_subsystems/battery/battery_variable_meta_data.py
@@ -10,14 +10,6 @@ ExtendedMetaData = av.CoreMetaData
 ##### BATTERY VALUES #####
 
 av.add_meta_data(
-    Aircraft.Battery.CELL_TYPE,
-    desc="Type of battery to use in performance maps",
-    default_value="18650",
-    option=True,
-    meta_data=ExtendedMetaData
-)
-
-av.add_meta_data(
     Aircraft.Battery.CURRENT_MAX,
     units="A",
     desc="Max current through the pack",

--- a/aviary/examples/external_subsystems/battery/battery_variables.py
+++ b/aviary/examples/external_subsystems/battery/battery_variables.py
@@ -14,7 +14,6 @@ class Aircraft(AviaryAircraft):
     # cell = single cell, battery = one case plus multiple cells
 
     class Battery:
-        CELL_TYPE = "aircraft:battery:cell_type"
         CURRENT_MAX = "aircraft:battery:current_max"
         EFFICIENCY = "aircraft:battery:efficiency"
         ENERGY_REQUIRED = "aircraft:battery:energy_required"

--- a/aviary/examples/external_subsystems/battery/model/battery_mission.py
+++ b/aviary/examples/external_subsystems/battery/model/battery_mission.py
@@ -38,11 +38,10 @@ class BatteryMission(Group):
 
     def setup(self):
         n = self.options["num_nodes"]
-        cell_type = self.options['aviary_inputs'].get_val(Aircraft.Battery.CELL_TYPE)
 
         self.add_subsystem(
             name="interp_group",
-            subsys=RegTheveninInterpGroup(num_nodes=n, cell_type=cell_type),
+            subsys=RegTheveninInterpGroup(num_nodes=n),
         )
 
         self.add_subsystem(name="cell", subsys=CellComp(num_nodes=n))

--- a/aviary/examples/external_subsystems/battery/model/reg_thevenin_interp_group.py
+++ b/aviary/examples/external_subsystems/battery/model/reg_thevenin_interp_group.py
@@ -10,11 +10,8 @@ class RegTheveninInterpGroup(Group):
     def initialize(self):
         self.options.declare('num_nodes', types=int)
 
-        self.options.declare('cell_type', types=str, default='18650')
-
     def setup(self):
         n = self.options['num_nodes']
-        cell_type = self.options['cell_type']
 
         thevenin_interp_comp = MetaModelStructuredComp(method='slinear', vec_size=n,
                                                        training_data_gradients=False, extrapolate=True)

--- a/aviary/examples/external_subsystems/battery/run_cruise.py
+++ b/aviary/examples/external_subsystems/battery/run_cruise.py
@@ -18,8 +18,6 @@ prob = av.AviaryProblem(phase_info, mission_method="simple", mass_method="FLOPS"
 # Allow for user overrides here
 prob.load_inputs('models/test_aircraft/aircraft_for_bench_FwFm.csv')
 
-prob.aviary_inputs.set_val(Aircraft.Battery.CELL_TYPE, "18650")
-
 prob.add_pre_mission_systems()
 
 prob.add_phases()

--- a/aviary/examples/external_subsystems/battery/run_multiphase_mission.py
+++ b/aviary/examples/external_subsystems/battery/run_multiphase_mission.py
@@ -24,8 +24,6 @@ prob = AviaryProblem(phase_info, mission_method="FLOPS", mass_method="FLOPS")
 # Allow for user overrides here
 prob.load_inputs(input_file)
 
-prob.aviary_inputs.set_val(Aircraft.Battery.CELL_TYPE, "18650")
-
 # Have checks for clashing user inputs
 # Raise warnings or errors depending on how clashing the issues are
 prob.check_inputs()

--- a/aviary/examples/external_subsystems/battery/test_battery_builder.py
+++ b/aviary/examples/external_subsystems/battery/test_battery_builder.py
@@ -10,7 +10,6 @@ class TestBattery(TestSubsystemBuilderBase):
     def setUp(self):
         self.subsystem_builder = BatteryBuilder()
         self.aviary_values = AviaryValues()
-        self.aviary_values.set_val(Aircraft.Battery.CELL_TYPE, '18650')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

This is a tiny PR that removes the flag for battery cell type in the battery external subsystem example. There was only one type of battery so the flag was never used.

### Related Issues

- NA

### Backwards incompatibilities

None

### New Dependencies

None