### PR TITLE
Preparing code for pypi

### DIFF
--- a/aviary/mission/gasp_based/ode/constraints/test/test_climb_constraints.py
+++ b/aviary/mission/gasp_based/ode/constraints/test/test_climb_constraints.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -7,7 +8,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 
 from aviary.mission.gasp_based.ode.constraints.speed_constraints import \
     SpeedConstraints
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Dynamic
 
 
@@ -42,6 +43,7 @@ class SpeedConstraintTestCase1(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'climb_specs/speeds.json')), "`climb_specs/speeds.json` does not exist")
     def test_speed_constraints_spec(self):
 
         subsystem = self.prob.model
@@ -80,6 +82,7 @@ class SpeedConstraintTestCase2(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'descent_specs/speeds.json')), "`descent_specs/speeds.json` does not exist")
     def test_speed_constraints_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/constraints/test/test_flight_constraints.py
+++ b/aviary/mission/gasp_based/ode/constraints/test/test_flight_constraints.py
@@ -50,7 +50,7 @@ class FlightConstraintTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=3e-11, rtol=1e-12)
 
-    @unittest.skipIf(not os.path.isfile(os.path.join('climb_specs/constraints.json', XDSM_PATH)), "`climb_specs/constraints.json` does not exist")
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'climb_specs/constraints.json')), "`climb_specs/constraints.json` does not exist")
     def test_flight_constraints_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "climb_specs/constraints.json")

--- a/aviary/mission/gasp_based/ode/constraints/test/test_flight_constraints.py
+++ b/aviary/mission/gasp_based/ode/constraints/test/test_flight_constraints.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -7,7 +8,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 
 from aviary.mission.gasp_based.ode.constraints.flight_constraints import \
     FlightConstraints
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Dynamic
 
 
@@ -49,9 +50,9 @@ class FlightConstraintTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=3e-11, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join('climb_specs/constraints.json', XDSM_PATH)), "`climb_specs/constraints.json` does not exist")
     def test_flight_constraints_spec(self):
         subsystem = self.prob.model
-
         assert_match_spec(subsystem, "climb_specs/constraints.json")
 
 

--- a/aviary/mission/gasp_based/ode/test/test_accel_eom.py
+++ b/aviary/mission/gasp_based/ode/test/test_accel_eom.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
                                          assert_near_equal)
 
 from aviary.mission.gasp_based.ode.accel_eom import AccelerationRates
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Dynamic
 
 
@@ -54,6 +55,7 @@ class AccelerationTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'accel_specs/eom.json')), "`accel_specs/eom.json` does not exist")
     def test_accel_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_accel_ode.py
+++ b/aviary/mission/gasp_based/ode/test/test_accel_ode.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
@@ -6,7 +7,8 @@ from openmdao.utils.assert_utils import assert_check_partials
 from aviary.mission.gasp_based.ode.accel_ode import AccelODE
 from aviary.variable_info.options import get_option_defaults
 from aviary.utils.test_utils.IO_test_util import (assert_match_spec,
-                                                  check_prob_outputs)
+                                                  check_prob_outputs,
+                                                  XDSM_PATH)
 from aviary.variable_info.variables import Dynamic
 from aviary.interface.default_phase_info.gasp import default_mission_subsystems
 
@@ -43,6 +45,7 @@ class AccelerationODETestCase(unittest.TestCase):
         )
         assert_check_partials(partial_data, rtol=1e-10)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/accelerate.json')), "`statics_specs/accelerate.json` does not exist")
     def test_accel_spec(self):
         """Test accel ODE spec"""
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_ascent_eom.py
+++ b/aviary/mission/gasp_based/ode/test/test_ascent_eom.py
@@ -1,11 +1,12 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from aviary.mission.gasp_based.ode.ascent_eom import AscentEOM
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Dynamic
 
 
@@ -40,6 +41,7 @@ class AscentEOMTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'ascent_specs/eom.json')), "`ascent_specs/eom.json` does not exist")
     def test_ascent_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_ascent_ode.py
+++ b/aviary/mission/gasp_based/ode/test/test_ascent_ode.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from aviary.mission.gasp_based.ode.ascent_ode import AscentODE
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.interface.default_phase_info.gasp import default_mission_subsystems
 from aviary.variable_info.options import get_option_defaults
 
@@ -30,6 +31,7 @@ class AscentODETestCase(unittest.TestCase):
         )
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/ascent.json')), "`statics_specs/ascent.json` does not exist")
     def test_ascent_spec(self):
         """Test ascent ODE spec"""
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_climb_eom.py
+++ b/aviary/mission/gasp_based/ode/test/test_climb_eom.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
                                          assert_near_equal)
 
 from aviary.mission.gasp_based.ode.climb_eom import ClimbRates
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Dynamic
 
 
@@ -60,6 +61,7 @@ class ClimbTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'climb_specs/eom.json')), "`climb_specs/eom.json` does not exist")
     def test_climb_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_climb_ode.py
+++ b/aviary/mission/gasp_based/ode/test/test_climb_ode.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -6,7 +7,8 @@ from openmdao.utils.assert_utils import assert_check_partials
 
 from aviary.mission.gasp_based.ode.climb_ode import ClimbODE
 from aviary.utils.test_utils.IO_test_util import (assert_match_spec,
-                                                  check_prob_outputs)
+                                                  check_prob_outputs,
+                                                  XDSM_PATH)
 from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Dynamic
 from aviary.interface.default_phase_info.gasp import default_mission_subsystems
@@ -93,10 +95,12 @@ class ClimbODETestCase(unittest.TestCase):
         }
         check_prob_outputs(self.prob, testvals, 1e-1)  # TODO tighten
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/climb1.json')), "`statics_specs/climb1.json` does not exist")
     def test_climb1_spec(self):
         """Test climb1 phase spec"""
         assert_match_spec(self.sys, "statics_specs/climb1.json")
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/climb2.json')), "`statics_specs/climb2.json` does not exist")
     def test_climb2_spec(self):
         """Test climb2 phase spec"""
         assert_match_spec(self.sys, "statics_specs/climb2.json")

--- a/aviary/mission/gasp_based/ode/test/test_descent_eom.py
+++ b/aviary/mission/gasp_based/ode/test/test_descent_eom.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
                                          assert_near_equal)
 
 from aviary.mission.gasp_based.ode.descent_eom import DescentRates
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Dynamic
 
 
@@ -62,6 +63,7 @@ class DescentTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'descent1_specs/eom.json')), "`descent1_specs/eom.json` does not exist")
     def test_descent_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_descent_ode.py
+++ b/aviary/mission/gasp_based/ode/test/test_descent_ode.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao
@@ -9,7 +10,8 @@ from packaging import version
 from aviary.mission.gasp_based.ode.descent_ode import DescentODE
 from aviary.variable_info.options import get_option_defaults
 from aviary.utils.test_utils.IO_test_util import (assert_match_spec,
-                                                  check_prob_outputs)
+                                                  check_prob_outputs,
+                                                  XDSM_PATH)
 from aviary.variable_info.enums import SpeedType
 from aviary.variable_info.variables import Dynamic
 from aviary.interface.default_phase_info.gasp import default_mission_subsystems
@@ -94,6 +96,7 @@ class DescentODETestCase(unittest.TestCase):
         )
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/descent1.json')), "`statics_specs/descent1.json` does not exist")
     def test_descent1_ode_spec(self):
         """Test descent1 phase spec"""
         self.sys.options["input_speed_type"] = SpeedType.MACH
@@ -101,6 +104,7 @@ class DescentODETestCase(unittest.TestCase):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "statics_specs/descent1.json")
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/descent2.json')), "`statics_specs/descent2.json` does not exist")
     def test_descent2_ode_spec(self):
         """Test descent2 phase spec"""
         self.sys.options["input_speed_type"] = SpeedType.EAS

--- a/aviary/mission/gasp_based/ode/test/test_groundroll_eom.py
+++ b/aviary/mission/gasp_based/ode/test/test_groundroll_eom.py
@@ -1,11 +1,12 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from aviary.mission.gasp_based.ode.groundroll_eom import GroundrollEOM
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Dynamic
 
 
@@ -42,6 +43,7 @@ class GroundrollEOMTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'groundroll_specs/eom.json')), "`groundroll_specs/eom.json` does not exist")
     def test_groundroll_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_groundroll_ode.py
+++ b/aviary/mission/gasp_based/ode/test/test_groundroll_ode.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from aviary.mission.gasp_based.ode.groundroll_ode import GroundrollODE
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.options import get_option_defaults
 from aviary.interface.default_phase_info.gasp import default_mission_subsystems
 
@@ -30,6 +31,7 @@ class GroundrollODETestCase(unittest.TestCase):
         )
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/groundroll.json')), "`statics_specs/groundroll.json` does not exist")
     def test_groundroll_spec(self):
         """Test groundroll ODE spec"""
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_rotation_eom.py
+++ b/aviary/mission/gasp_based/ode/test/test_rotation_eom.py
@@ -1,11 +1,12 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from aviary.mission.gasp_based.ode.rotation_eom import RotationEOM
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Dynamic
 
 
@@ -40,6 +41,7 @@ class RotationEOMTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'rotation_specs/eom.json')), "`rotation_specs/eom.json` does not exist")
     def test_rotation_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/ode/test/test_rotation_ode.py
+++ b/aviary/mission/gasp_based/ode/test/test_rotation_ode.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from aviary.mission.gasp_based.ode.rotation_ode import RotationODE
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Dynamic
 from aviary.interface.default_phase_info.gasp import default_mission_subsystems
@@ -34,6 +35,7 @@ class RotationODETestCase(unittest.TestCase):
         )
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/rotation.json')), "`statics_specs/rotation.json` does not exist")
     def test_rotation_spec(self):
         """Test rotation ODE spec"""
         subsystem = self.prob.model

--- a/aviary/mission/gasp_based/phases/test/test_breguet.py
+++ b/aviary/mission/gasp_based/phases/test/test_breguet.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -7,7 +8,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 
 from aviary.constants import GRAV_ENGLISH_LBM
 from aviary.mission.gasp_based.phases.breguet import RangeComp
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Dynamic
 
 
@@ -45,6 +46,7 @@ class TestBreguetResults(unittest.TestCase):
             partial_data = self.prob.check_partials(method="cs")  # , out_stream=None)
         assert_check_partials(partial_data, atol=tol, rtol=tol)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'cruise_specs/breguet_eom.json')), "`cruise_specs/breguet_eom.json` does not exist")
     def test_climb_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "cruise_specs/breguet_eom.json")

--- a/aviary/mission/gasp_based/phases/test/test_landing_components.py
+++ b/aviary/mission/gasp_based/phases/test/test_landing_components.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import (assert_check_partials,
@@ -7,7 +8,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 from aviary.mission.gasp_based.phases.landing_components import (
     GlideConditionComponent, LandingAltitudeComponent,
     LandingGroundRollComponent)
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Mission
 
 
@@ -37,6 +38,7 @@ class LandingAltTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'landing_specs/landing_alt.json')), "`landing_specs/landing_alt.json` does not exist")
     def test_alt_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "landing_specs/landing_alt.json")
@@ -114,6 +116,7 @@ class GlideTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-10, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'landing_specs/glide.json')), "`landing_specs/glide.json` does not exist")
     def test_alt_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "landing_specs/glide.json")
@@ -165,6 +168,7 @@ class GroundRollTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=5e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'landing_specs/groundroll.json')), "`landing_specs/groundroll.json` does not exist")
     def test_alt_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "landing_specs/groundroll.json")

--- a/aviary/mission/gasp_based/phases/test/test_landing_group.py
+++ b/aviary/mission/gasp_based/phases/test/test_landing_group.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao
@@ -9,7 +10,8 @@ from packaging import version
 from aviary.mission.gasp_based.phases.landing_group import LandingSegment
 from aviary.variable_info.options import get_option_defaults
 from aviary.utils.test_utils.IO_test_util import (assert_match_spec,
-                                                  check_prob_outputs)
+                                                  check_prob_outputs,
+                                                  XDSM_PATH)
 from aviary.variable_info.variables import Dynamic, Mission
 
 
@@ -53,6 +55,7 @@ class DLandTestCase(unittest.TestCase):
         )
         assert_check_partials(partial_data, atol=1e-6, rtol=1e-6)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/landing.json')), "`statics_specs/landing.json` does not exist")
     def test_dland_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "statics_specs/landing.json")

--- a/aviary/mission/gasp_based/phases/test/test_taxi_component.py
+++ b/aviary/mission/gasp_based/phases/test/test_taxi_component.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import (assert_check_partials,
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 
 from aviary.utils.aviary_values import AviaryValues
 from aviary.mission.gasp_based.phases.taxi_component import TaxiFuelComponent
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Dynamic, Mission
 
 
@@ -32,6 +33,7 @@ class TaxiFuelComponentTestCase(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'taxi_specs/fuel.json')), "`taxi_specs/fuel.json` does not exist")
     def test_fuel_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "taxi_specs/fuel.json")

--- a/aviary/mission/gasp_based/phases/test/test_taxi_group.py
+++ b/aviary/mission/gasp_based/phases/test/test_taxi_group.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao
@@ -9,7 +10,8 @@ from packaging import version
 from aviary.mission.gasp_based.phases.landing_group import LandingSegment
 from aviary.variable_info.options import get_option_defaults
 from aviary.utils.test_utils.IO_test_util import (assert_match_spec,
-                                                  check_prob_outputs)
+                                                  check_prob_outputs,
+                                                  XDSM_PATH)
 from aviary.variable_info.variables import Dynamic, Mission
 
 
@@ -53,6 +55,7 @@ class DLandTestCase(unittest.TestCase):
         )
         assert_check_partials(partial_data, atol=1e-6, rtol=1e-6)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/landing.json')), "`statics_specs/landing.json` does not exist")
     def test_dland_spec(self):
         subsystem = self.prob.model
         assert_match_spec(subsystem, "statics_specs/landing.json")

--- a/aviary/mission/gasp_based/test/test_flight_conditions.py
+++ b/aviary/mission/gasp_based/test/test_flight_conditions.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao.api as om
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
                                          assert_near_equal)
 
 from aviary.mission.gasp_based.flight_conditions import FlightConditions
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.enums import SpeedType
 from aviary.variable_info.variables import Dynamic
 
@@ -47,6 +48,7 @@ class FlightConditionsTestCase1(unittest.TestCase):
 
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'accel_specs/fc.json')), "`accel_specs/fc.json` does not exist")
     def test_fc_spec1(self):
 
         subsystem = self.prob.model
@@ -89,6 +91,7 @@ class FlightConditionsTestCase2(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'climb_specs/fc.json')), "`climb_specs/fc.json` does not exist")
     def test_fc_spec2(self):
 
         subsystem = self.prob.model
@@ -132,6 +135,7 @@ class FlightConditionsTestCase3(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'cruise_specs/fc.json')), "`cruise_specs/fc.json` does not exist")
     def test_fc_spec3(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_Clmax.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_Clmax.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import (assert_check_partials,
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 
 from aviary.subsystems.aerodynamics.gasp_based.flaps_model.Cl_max import \
     CLmaxCalculation
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Dynamic
 
 """
@@ -74,6 +75,7 @@ class CLmaxCalculationTestCase(unittest.TestCase):
             data, atol=6400, rtol=0.007
         )  # large to account for large magnitude value, discrepancies are acceptable
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'flaps_specs/CL_max.json')), "`flaps_specs/CL_max.json` does not exist")
     def test_CLmax_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_basic_calculations.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_basic_calculations.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import (assert_check_partials,
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 
 from aviary.subsystems.aerodynamics.gasp_based.flaps_model.basic_calculations import \
     BasicFlapsCalculations
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft
 
 """
@@ -84,6 +85,7 @@ class BasicFlapsCalculationsTestCase(unittest.TestCase):
         data = self.prob.check_partials(out_stream=None, method="fd")
         assert_check_partials(data, atol=1e-6, rtol=4e-6)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'flaps_specs/basic.json')), "`flaps_specs/basic.json` does not exist")
     def test_basic_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_increments.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_increments.py
@@ -1,11 +1,12 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from aviary.subsystems.aerodynamics.gasp_based.flaps_model.L_and_D_increments import \
     LiftAndDragIncrements
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft
 
 """
@@ -56,6 +57,7 @@ class LiftAndDragIncrementsTestCase(unittest.TestCase):
         data = self.prob.check_partials(out_stream=None, method="fd")
         assert_check_partials(data, atol=1e-4, rtol=1e-4)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'flaps_specs/increments.json')), "`flaps_specs/increments.json` does not exist")
     def test_increment_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_metamodel.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/flaps_model/test/test_metamodel.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import (assert_check_partials,
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import (assert_check_partials,
 
 from aviary.subsystems.aerodynamics.gasp_based.flaps_model.meta_model import \
     MetaModelGroup
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.enums import Flap_Type
 from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Dynamic
@@ -108,6 +109,7 @@ class MetaModelTestCasePlain(unittest.TestCase):
         data = self.prob.check_partials(out_stream=None, method="fd")
         assert_check_partials(data, atol=1e-4, rtol=1e-4)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'flaps_specs/tables.json')), "`flaps_specs/tables.json` does not exist")
     def test_lookup_spec(self):
 
         subsystem = self.prob.model
@@ -153,6 +155,7 @@ class MetaModelTestCaseSingleSlotted(unittest.TestCase):
         data = self.prob.check_partials(out_stream=None, method="fd")
         assert_check_partials(data, atol=1e-4, rtol=1e-4)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'flaps_specs/tables.json')), "`flaps_specs/tables.json` does not exist")
     def test_lookup_spec(self):
 
         subsystem = self.prob.model
@@ -188,6 +191,7 @@ class MetaModelTestCaseFowler(unittest.TestCase):
         data = self.prob.check_partials(out_stream=None, method="fd")
         assert_check_partials(data, atol=1e-4, rtol=1e-4)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'flaps_specs/tables.json')), "`flaps_specs/tables.json` does not exist")
     def test_lookup_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/aerodynamics/gasp_based/test/test_table_based.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/test/test_table_based.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 import openmdao
@@ -9,7 +10,7 @@ from packaging import version
 
 from aviary.subsystems.aerodynamics.gasp_based.table_based import (
     CruiseAero, LowSpeedAero)
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Dynamic
 
 
@@ -87,6 +88,7 @@ class TestLowSpeedAero(unittest.TestCase):
     ground_data = pkg_resources.resource_filename(
         "aviary", f"subsystems/aerodynamics/gasp_based/data/large_single_aisle_1_aero_ground.txt")
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'rotation_specs/aero.json')), "`rotation_specs/aero.json` does not exist")
     def test_spec(self):
         comp = LowSpeedAero(free_aero_data=self.free_data,
                             flaps_aero_data=self.flaps_data,

--- a/aviary/subsystems/geometry/gasp_based/test/test_empennage.py
+++ b/aviary/subsystems/geometry/gasp_based/test/test_empennage.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from aviary.subsystems.geometry.gasp_based.empennage import (EmpennageSize,
                                                              TailSize,
                                                              TailVolCoef)
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
@@ -184,6 +185,7 @@ class TestEmpennageGroup(
             self.prob[Aircraft.VerticalTail.MOMENT_ARM], 49.87526, tol
         )  # note: slightly different from GASP output value, likely numerical diff.s, this value is from Kenny
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'size_both1_specs/empennage.json')), "`size_both1_specs/empennage.json` does not exist")
     def test_io_emp_spec_defaults(self):
         self.prob.model.emp.options["aviary_options"] = get_option_defaults()
 
@@ -216,6 +218,7 @@ class TestEmpennageGroup(
             self.prob[Aircraft.VerticalTail.VOLUME_COEFFICIENT], 0.11623, tol
         )  # not actual GASP value
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'size_both2_specs/empennage.json')), "`size_both2_specs/empennage.json` does not exist")
     def test_io_emp_spec_vol_coefs(self):
         options = get_option_defaults()
         options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF,

--- a/aviary/subsystems/geometry/gasp_based/test/test_size_group.py
+++ b/aviary/subsystems/geometry/gasp_based/test/test_size_group.py
@@ -1,11 +1,12 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from aviary.subsystems.geometry.gasp_based.size_group import SizeGroup
 from aviary.variable_info.options import get_option_defaults
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Mission
 
 # this is the GASP test case, input and output values based on large single aisle 1 v3 without bug fix
@@ -158,6 +159,7 @@ class SizeGroupTestCase1(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=2e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_basic_specs/size.json')), "`mass_and_sizing_basic_specs/size.json` does not exist")
     def test_io_wing_group_spec(self):
 
         subsystem = self.prob.model
@@ -388,6 +390,7 @@ class SizeGroupTestCase2(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=3e-10, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_both_specs/size.json')), "`mass_and_sizing_both_specs/size.json` does not exist")
     def test_io_wing_group_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/geometry/gasp_based/test/test_wing.py
+++ b/aviary/subsystems/geometry/gasp_based/test/test_wing.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -7,7 +8,7 @@ from aviary.subsystems.geometry.gasp_based.wing import (WingFold, WingGroup,
                                                         WingParameters,
                                                         WingSize)
 from aviary.variable_info.options import get_option_defaults
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Mission
 
 
@@ -309,6 +310,7 @@ class WingGroupTestCase1(
 
         self.prob.setup(check=False, force_alloc_complex=True)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'size_basic_specs/wing.json')), "`size_basic_specs/wing.json` does not exist")
     def test_io_wing_group_spec(self):
 
         subsystem = self.prob.model
@@ -392,6 +394,7 @@ class WingGroupTestCase2(unittest.TestCase):
 
         self.prob.setup(check=False, force_alloc_complex=True)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'size_both1_specs/wing.json')), "`size_both1_specs/wing.json` does not exist")
     def test_io_wing_group_spec(self):
 
         subsystem = self.prob.model
@@ -560,6 +563,7 @@ class WingGroupTestCase4(unittest.TestCase):
 
         self.prob.setup(check=False, force_alloc_complex=True)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'size_both2_specs/wing.json')), "`size_both2_specs/wing.json` does not exist")
     def test_io_wing_group_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/mass/gasp_based/test/test_design_load.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_design_load.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -8,7 +9,7 @@ from aviary.subsystems.mass.gasp_based.design_load import (DesignLoadGroup,
                                                            LoadParameters,
                                                            LoadSpeeds)
 from aviary.variable_info.options import get_option_defaults
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Mission
 
 
@@ -879,6 +880,7 @@ class DesignLoadGroupTestCase1(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-7, rtol=2e-7)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_basic_specs/design_load.json')), "`mass_and_sizing_basic_specs/design_load.json` does not exist")
     def test_io_fixed_group_spec(self):
 
         subsystem = self.prob.model
@@ -930,6 +932,7 @@ class DesignLoadGroupTestCase2smooth(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-7, rtol=2e-7)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_basic_specs/design_load.json')), "`mass_and_sizing_basic_specs/design_load.json` does not exist")
     def test_io_fixed_group_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/mass/gasp_based/test/test_equipment_and_useful_load.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_equipment_and_useful_load.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -6,7 +7,7 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from aviary.subsystems.mass.gasp_based.equipment_and_useful_load import \
     EquipAndUsefulLoadMass
 from aviary.variable_info.options import get_option_defaults
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.enums import GASP_Engine_Type
 from aviary.variable_info.variables import Aircraft, Mission
 
@@ -604,6 +605,7 @@ class EquipAndUsefulMassGroupTestCase1(
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_basic_specs/equip.json')), "`mass_and_sizing_basic_specs/equip.json` does not exist")
     def test_io_equip_and_useful_group_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/mass/gasp_based/test/test_fixed.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fixed.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -13,7 +14,7 @@ from aviary.subsystems.mass.gasp_based.fixed import (ControlMass,
                                                      PayloadMass, TailMass)
 from aviary.utils.aviary_values import AviaryValues, get_keys
 from aviary.variable_info.options import get_option_defaults
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Mission
 
 
@@ -1115,6 +1116,7 @@ class FixedMassGroupTestCase1(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=3e-11, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_both_specs/fixed_mass.json')), "`mass_and_sizing_both_specs/fixed_mass.json` does not exist")
     def test_io_fixed_group_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/mass/gasp_based/test/test_fuel.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fuel.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -9,7 +10,7 @@ from aviary.subsystems.mass.gasp_based.fuel import (BodyTankCalculations,
                                                     FuelSysAndFullFuselageMass,
                                                     FuselageAndStructMass)
 from aviary.variable_info.options import get_option_defaults
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Mission
 
 
@@ -610,6 +611,7 @@ class FuelMassGroupTestCase2(
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=2e-11, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_basic_specs/fuel_mass.json')), "`mass_and_sizing_basic_specs/fuel_mass.json` does not exist")
     def test_io_fuel_group_spec(self):
 
         subsystem = self.prob.model
@@ -744,6 +746,7 @@ class FuelMassGroupTestCase3(
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=3e-9, rtol=6e-11)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_basic_specs/fuel_mass.json')), "`mass_and_sizing_basic_specs/fuel_mass.json` does not exist")
     def test_io_fuel_group_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -7,7 +8,7 @@ from aviary.subsystems.geometry.gasp_based.size_group import SizeGroup
 from aviary.subsystems.mass.gasp_based.mass_premission import MassPremission
 from aviary.utils.aviary_values import get_items
 from aviary.variable_info.options import get_option_defaults, is_option
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.models.large_single_aisle_1.V3_bug_fixed_IO import (
     V3_bug_fixed_non_metadata, V3_bug_fixed_options)
 from aviary.variable_info.variables import Aircraft, Mission
@@ -157,6 +158,7 @@ class MassSummationTestCase1(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=3e-10, rtol=1e-12)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'statics_specs/mass.json')), "`statics_specs/mass.json` does not exist")
     def test_mass_spec(self):
 
         subsystem = self.prob.model

--- a/aviary/subsystems/mass/gasp_based/test/test_wing.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_wing.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
@@ -7,7 +8,7 @@ from aviary.subsystems.mass.gasp_based.wing import (WingMassGroup,
                                                     WingMassSolve,
                                                     WingMassTotal)
 from aviary.variable_info.options import get_option_defaults
-from aviary.utils.test_utils.IO_test_util import assert_match_spec
+from aviary.utils.test_utils.IO_test_util import assert_match_spec, XDSM_PATH
 from aviary.variable_info.variables import Aircraft, Mission
 
 
@@ -270,6 +271,7 @@ class WingMassGroupTestCase1(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_basic_specs/wing_mass.json')), "`mass_and_sizing_basic_specs/wing_mass.json` does not exist")
     def test_io_equip_and_useful_group_spec(self):
 
         subsystem = self.prob.model
@@ -470,6 +472,7 @@ class WingMassGroupTestCase4(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
+    @unittest.skipIf(not os.path.isfile(os.path.join(XDSM_PATH, 'mass_and_sizing_both_specs/wing_mass.json')), "`mass_and_sizing_both_specs/wing_mass.json` does not exist")
     def test_io_equip_and_useful_group_spec(self):
 
         subsystem = self.prob.model

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ __version__ = re.findall(
     open('aviary/__init__.py').read(),
 )[0]
 
+with open(Path(__file__).parent / "README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
 pkgname = "aviary"
 extras_require = {
     "test": ["testflo", "pyxdsm", "pre-commit"],
@@ -22,7 +25,9 @@ for packages in extras_require.values():
 extras_require["all"] = all_packages
 
 setup(
-    name=pkgname,
+    name="om-aviary",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     version=__version__,
     packages=find_packages(),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import find_packages, setup
+from pathlib import Path
 import re
 
 


### PR DESCRIPTION
### Summary

This PR is a stepping stone on the way to preparing Aviary for packaging on pypi. The changes here are both necessary in order to ensure proper installation on pypi. Changes are:
- in setup.py the package name is changed to match what the package name with be on pypi, and a long description that loads the README.md file is added.
- In spec tests a test skip is added if the `.json` files do not exist. The reason for this is that on pypi the user will not be able to build these files and the tests will fail.

### Related Issues

- Resolves None

### Backwards incompatibilities

None

### New Dependencies

None