### PR TITLE
Skipping tests for external subsystems with missing dependencies

### DIFF
--- a/aviary/examples/external_subsystems/OAS_weight/test_OAS_wing_weight_builder.py
+++ b/aviary/examples/external_subsystems/OAS_weight/test_OAS_wing_weight_builder.py
@@ -1,9 +1,13 @@
 import unittest
 import aviary.api as av
 
-from aviary.examples.external_subsystems.OAS_weight.OAS_wing_weight_builder import OASWingWeightBuilder
+try:
+    from aviary.examples.external_subsystems.OAS_weight.OAS_wing_weight_builder import OASWingWeightBuilder
+    missing_dependecies = False
+except ImportError:
+    missing_dependecies = True
 
-
+@unittest.skipIf(missing_dependecies, "Skipping due to missing dependencies")
 class TestStructures(av.TestSubsystemBuilderBase):
 
     def setUp(self):

--- a/aviary/examples/external_subsystems/OAS_weight/test_OAS_wing_weight_builder.py
+++ b/aviary/examples/external_subsystems/OAS_weight/test_OAS_wing_weight_builder.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     missing_dependecies = True
 
+
 @unittest.skipIf(missing_dependecies, "Skipping due to missing dependencies")
 class TestStructures(av.TestSubsystemBuilderBase):
 

--- a/aviary/examples/external_subsystems/battery/test_battery_builder.py
+++ b/aviary/examples/external_subsystems/battery/test_battery_builder.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     missing_dependecies = True
 
+
 @unittest.skipIf(missing_dependecies, "Skipping due to missing dependencies")
 class TestBattery(TestSubsystemBuilderBase):
 

--- a/aviary/examples/external_subsystems/battery/test_battery_builder.py
+++ b/aviary/examples/external_subsystems/battery/test_battery_builder.py
@@ -1,10 +1,15 @@
 import unittest
 from aviary.subsystems.test.subsystem_tester import TestSubsystemBuilderBase
-from aviary.examples.external_subsystems.battery.battery_builder import BatteryBuilder
-from aviary.examples.external_subsystems.battery.battery_variables import Aircraft
 from aviary.utils.aviary_values import AviaryValues
 
+try:
+    from aviary.examples.external_subsystems.battery.battery_builder import BatteryBuilder
+    from aviary.examples.external_subsystems.battery.battery_variables import Aircraft
+    missing_dependecies = False
+except ImportError:
+    missing_dependecies = True
 
+@unittest.skipIf(missing_dependecies, "Skipping due to missing dependencies")
 class TestBattery(TestSubsystemBuilderBase):
 
     def setUp(self):


### PR DESCRIPTION
### Summary

Modified tests of external subsystems to skip if dependencies aren't installed.
This prevents test failures for users with only core Aviary installed

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None