### PR TITLE
Onboarding external subsystem update

### DIFF
--- a/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
+++ b/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
@@ -50,6 +50,7 @@
     "\n",
     "from aviary.examples.external_subsystems.simple_weight.simple_weight_builder import WingWeightBuilder\n",
     "\n",
+    "# Max iterations set to 1 to reduce runtime of example\n",
     "max_iter = 1\n",
     "phase_info = deepcopy(av.default_simple_phase_info)\n",
     "# Here we just add the simple weight system to only the pre-mission\n",
@@ -112,6 +113,7 @@
     "# # Here we just add the simple weight system to only the pre-mission\n",
     "# phase_info['pre_mission']['external_subsystems'] = [WingWeightBuilder(name=\"wing_external\")]\n",
     "\n",
+    "# Max iterations set to 1 to reduce runtime of example\n",
     "max_iter = 1\n",
     "prob = av.AviaryProblem(av.default_simple_phase_info, mission_method=\"simple\", mass_method=\"FLOPS\")\n",
     "\n",
@@ -486,7 +488,7 @@
    "source": [
     "### Running the OpenAeroStruct Example\n",
     "\n",
-    "We are ready to run this example. First, we build an `OAStructures`."
+    "We are ready to run this example. First, we create an `OASWingWeightBuilder` instance."
    ]
   },
   {
@@ -509,7 +511,8 @@
    "id": "3f657b61",
    "metadata": {},
    "source": [
-    "Let's add a few phases in the mission. In particular, let's add `OAStructures` external subsystem to `pre_mission`."
+    "Let's add a few phases in the mission. In particular, let's add the object we just created as an external subsystem to `pre_mission`.\n",
+    "We are only adding to `pre_mission` here as the OpenAeroStruct design is only done in the sizing portion of pre-mission and doesn't need to be called during the mission."
    ]
   },
   {
@@ -609,7 +612,7 @@
    "id": "0f1ce46e",
    "metadata": {},
    "source": [
-    "Start an Aviary problem, load in aircraft input deck and do routine input checks:"
+    "We can now create an Aviary problem, load in an aircraft input deck, and do routine input checks:"
    ]
   },
   {
@@ -641,7 +644,7 @@
    "id": "0802ff94",
    "metadata": {},
    "source": [
-    "Next we select driver and setup the problem:"
+    "Next we select the driver and call setup on the problem:"
    ]
   },
   {
@@ -670,7 +673,7 @@
    "id": "354d81f3",
    "metadata": {},
    "source": [
-    "We need to set up OpenAeroStruct parameters before calling OpenAeroStruct:"
+    "Now we need to set some OpenAeroStruct-specific parameters before running Aviary:"
    ]
   },
   {
@@ -706,7 +709,9 @@
    "id": "d345e83d",
    "metadata": {},
    "source": [
-    "We are ready to run Aviary on this model. Note that there are multiple number of optimization loops in this run even though we have set `max_iter` to 0. This is because OpenAeroStruct has an optimization process internally. In order to shorten the runtime, we have set `run_driver = False`. This means that we will not run optimization but [run model](https://openmdao.org/newdocs/versions/latest/features/core_features/running_your_models/run_model.html). "
+    "We are now ready to run Aviary on this model.\n",
+    "Note that there are multiple number of optimization loops that are outputted from this run even though we have set `max_iter` to 0.\n",
+    "This is because OpenAeroStruct has an optimization process internally. In order to shorten the runtime, we have set `run_driver = False`. This means that we will not run optimization but [run model](https://openmdao.org/newdocs/versions/latest/features/core_features/running_your_models/run_model.html). "
    ]
   },
   {

--- a/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
+++ b/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "from aviary.examples.external_subsystems.simple_weight.simple_weight_builder import WingWeightBuilder\n",
     "\n",
-    "\n",
+    "max_iter = 1\n",
     "phase_info = deepcopy(av.default_simple_phase_info)\n",
     "# Here we just add the simple weight system to only the pre-mission\n",
     "phase_info['pre_mission']['external_subsystems'] = [WingWeightBuilder(name=\"wing_external\")]\n",
@@ -74,7 +74,7 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\")\n",
+    "prob.add_driver(\"SLSQP\", max_iter)\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -112,6 +112,7 @@
     "# # Here we just add the simple weight system to only the pre-mission\n",
     "# phase_info['pre_mission']['external_subsystems'] = [WingWeightBuilder(name=\"wing_external\")]\n",
     "\n",
+    "max_iter = 1\n",
     "prob = av.AviaryProblem(av.default_simple_phase_info, mission_method=\"simple\", mass_method=\"FLOPS\")\n",
     "\n",
     "# Load aircraft and options data from user\n",
@@ -131,7 +132,7 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\")\n",
+    "prob.add_driver(\"SLSQP\", max_iter)\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -296,7 +297,8 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\")\n",
+    "max_iter = 1\n",
+    "prob.add_driver(\"SLSQP\", max_iter)\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -414,7 +416,7 @@
    "source": [
     "## Adding an OpenAeroStruct wingbox external subsystem\n",
     "\n",
-    "[OpenAeroStruct](https://github.com/mdolab/OpenAerostruct/) (OAS) is a lightweight tool that performs aerostructural optimization using OpenMDAO."
+    "[OpenAeroStruct](https://github.com/mdolab/OpenAerostruct/) (OAS) is a lightweight tool that performs aerostructural optimization using OpenMDAO. This is an example that shows you how to use an existing external package with Aviary."
    ]
   },
   {
@@ -465,6 +467,272 @@
     "```\n",
     "\n",
     "Windows users should visit [OpenVSP](http://openvsp.org/download.php) and follow the instruction there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3eb10495",
+   "metadata": {},
+   "source": [
+    "### Understanding the OpenAeroStruct Example\n",
+    "\n",
+    "The OpenAeroStruct example is explained in detail in [Using Aviary and OpenAeroStruct Together](../examples/OAS_subsystem)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9d285b7",
+   "metadata": {},
+   "source": [
+    "### Running the OpenAeroStruct Example\n",
+    "\n",
+    "We are ready to run this example. First, we build an `OAStructures`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e4482ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import openmdao.api as om\n",
+    "import aviary.api as av\n",
+    "from aviary.examples.external_subsystems.OAS_weight.OAS_wing_weight_builder import OASWingWeightBuilder\n",
+    "\n",
+    "wing_weight_builder = OASWingWeightBuilder()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f657b61",
+   "metadata": {},
+   "source": [
+    "Let's add a few phases in the mission. In particular, let's add `OAStructures` external subsystem to `pre_mission`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d779a398",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the phase_info and other common setup tasks\n",
+    "phase_info = {\n",
+    "    'climb_1': {\n",
+    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
+    "        'user_options': {\n",
+    "            'optimize_mach': False,\n",
+    "            'optimize_altitude': False,\n",
+    "            'polynomial_control_order': 1,\n",
+    "            'num_segments': 5,\n",
+    "            'order': 3,\n",
+    "            'solve_for_range': False,\n",
+    "            'initial_mach': (0.2, 'unitless'),\n",
+    "            'final_mach': (0.72, 'unitless'),\n",
+    "            'mach_bounds': ((0.18, 0.74), 'unitless'),\n",
+    "            'initial_altitude': (0.0, 'ft'),\n",
+    "            'final_altitude': (32000.0, 'ft'),\n",
+    "            'altitude_bounds': ((0.0, 34000.0), 'ft'),\n",
+    "            'throttle_enforcement': 'path_constraint',\n",
+    "            'fix_initial': True,\n",
+    "            'constrain_final': False,\n",
+    "            'fix_duration': False,\n",
+    "            'initial_bounds': ((0.0, 0.0), 'min'),\n",
+    "            'duration_bounds': ((64.0, 192.0), 'min'),\n",
+    "        },\n",
+    "        'initial_guesses': {'times': ([0, 128], 'min')},\n",
+    "    },\n",
+    "    'climb_2': {\n",
+    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
+    "        'user_options': {\n",
+    "            'optimize_mach': False,\n",
+    "            'optimize_altitude': False,\n",
+    "            'polynomial_control_order': 1,\n",
+    "            'num_segments': 5,\n",
+    "            'order': 3,\n",
+    "            'solve_for_range': False,\n",
+    "            'initial_mach': (0.72, 'unitless'),\n",
+    "            'final_mach': (0.72, 'unitless'),\n",
+    "            'mach_bounds': ((0.7, 0.74), 'unitless'),\n",
+    "            'initial_altitude': (32000.0, 'ft'),\n",
+    "            'final_altitude': (34000.0, 'ft'),\n",
+    "            'altitude_bounds': ((23000.0, 38000.0), 'ft'),\n",
+    "            'throttle_enforcement': 'boundary_constraint',\n",
+    "            'fix_initial': False,\n",
+    "            'constrain_final': False,\n",
+    "            'fix_duration': False,\n",
+    "            'initial_bounds': ((64.0, 192.0), 'min'),\n",
+    "            'duration_bounds': ((56.5, 169.5), 'min'),\n",
+    "        },\n",
+    "        'initial_guesses': {'times': ([128, 113], 'min')},\n",
+    "    },\n",
+    "    'descent_1': {\n",
+    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
+    "        'user_options': {\n",
+    "            'optimize_mach': False,\n",
+    "            'optimize_altitude': False,\n",
+    "            'polynomial_control_order': 1,\n",
+    "            'num_segments': 5,\n",
+    "            'order': 3,\n",
+    "            'solve_for_range': False,\n",
+    "            'initial_mach': (0.72, 'unitless'),\n",
+    "            'final_mach': (0.36, 'unitless'),\n",
+    "            'mach_bounds': ((0.34, 0.74), 'unitless'),\n",
+    "            'initial_altitude': (34000.0, 'ft'),\n",
+    "            'final_altitude': (500.0, 'ft'),\n",
+    "            'altitude_bounds': ((0.0, 38000.0), 'ft'),\n",
+    "            'throttle_enforcement': 'path_constraint',\n",
+    "            'fix_initial': False,\n",
+    "            'constrain_final': True,\n",
+    "            'fix_duration': False,\n",
+    "            'initial_bounds': ((120.5, 361.5), 'min'),\n",
+    "            'duration_bounds': ((29.0, 87.0), 'min'),\n",
+    "        },\n",
+    "        'initial_guesses': {'times': ([241, 58], 'min')},\n",
+    "    },\n",
+    "    'post_mission': {\n",
+    "        'include_landing': False,\n",
+    "        'constrain_range': True,\n",
+    "        'target_range': (1800., 'nmi'),\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "phase_info['pre_mission'] = {'include_takeoff': False, 'optimize_mass': True}\n",
+    "phase_info['pre_mission']['external_subsystems'] = [wing_weight_builder]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f1ce46e",
+   "metadata": {},
+   "source": [
+    "Start an Aviary problem, load in aircraft input deck and do routine input checks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bef599e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aircraft_definition_file = 'models/test_aircraft/aircraft_for_bench_FwFm.csv'\n",
+    "mission_method = 'simple'\n",
+    "mass_method = 'FLOPS'\n",
+    "make_plots = False\n",
+    "max_iter = 0\n",
+    "optimizer = 'SNOPT'\n",
+    "\n",
+    "prob = av.AviaryProblem(phase_info, mission_method=mission_method, mass_method='FLOPS')\n",
+    "\n",
+    "prob.load_inputs(aircraft_definition_file)\n",
+    "prob.check_inputs()\n",
+    "prob.add_pre_mission_systems()\n",
+    "prob.add_phases()\n",
+    "prob.add_post_mission_systems()\n",
+    "prob.link_phases()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0802ff94",
+   "metadata": {},
+   "source": [
+    "Next we select driver and setup the problem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4491a9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver = prob.driver = om.pyOptSparseDriver()\n",
+    "driver.options[\"optimizer\"] = optimizer\n",
+    "driver.declare_coloring()\n",
+    "driver.opt_settings[\"Major iterations limit\"] = max_iter\n",
+    "driver.opt_settings[\"Major optimality tolerance\"] = 1e-4\n",
+    "driver.opt_settings[\"Major feasibility tolerance\"] = 1e-5\n",
+    "driver.opt_settings[\"iSumm\"] = 6\n",
+    "\n",
+    "prob.add_design_variables()\n",
+    "prob.add_objective()\n",
+    "prob.setup()\n",
+    "prob.set_initial_guesses()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "354d81f3",
+   "metadata": {},
+   "source": [
+    "We need to set up OpenAeroStruct parameters before calling OpenAeroStruct:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d83c778",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OAS_sys = 'pre_mission.wing_weight.aerostructures.'\n",
+    "prob.set_val(OAS_sys + 'box_upper_x', np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'box_lower_x', np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'box_upper_y', np.array([ 0.0447,  0.046,  0.0472,  0.0484,  0.0495,  0.0505,  0.0514,  0.0523,  0.0531,  0.0538, 0.0545,  0.0551,  0.0557, 0.0563,  0.0568, 0.0573,  0.0577,  0.0581,  0.0585,  0.0588,  0.0591,  0.0593,  0.0595,  0.0597,  0.0599,  0.06,    0.0601,  0.0602,  0.0602,  0.0602,  0.0602,  0.0602,  0.0601,  0.06,    0.0599,  0.0598,  0.0596,  0.0594,  0.0592,  0.0589,  0.0586,  0.0583,  0.058,   0.0576,  0.0572,  0.0568,  0.0563,  0.0558,  0.0553,  0.0547,  0.0541]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'box_lower_y', np.array([-0.0447, -0.046, -0.0473, -0.0485, -0.0496, -0.0506, -0.0515, -0.0524, -0.0532, -0.054, -0.0547, -0.0554, -0.056, -0.0565, -0.057, -0.0575, -0.0579, -0.0583, -0.0586, -0.0589, -0.0592, -0.0594, -0.0595, -0.0596, -0.0597, -0.0598, -0.0598, -0.0598, -0.0598, -0.0597, -0.0596, -0.0594, -0.0592, -0.0589, -0.0586, -0.0582, -0.0578, -0.0573, -0.0567, -0.0561, -0.0554, -0.0546, -0.0538, -0.0529, -0.0519, -0.0509, -0.0497, -0.0485, -0.0472, -0.0458, -0.0444]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'twist_cp', np.array([-6., -6., -4., 0.]), units='deg')\n",
+    "prob.set_val(OAS_sys + 'spar_thickness_cp', np.array([0.004, 0.005, 0.008, 0.01]), units='m')\n",
+    "prob.set_val(OAS_sys + 'skin_thickness_cp', np.array([0.005, 0.01, 0.015, 0.025]), units='m')\n",
+    "prob.set_val(OAS_sys + 't_over_c_cp', np.array([0.08, 0.08, 0.10, 0.08]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'airfoil_t_over_c', 0.12, units='unitless')\n",
+    "prob.set_val(OAS_sys + 'fuel', 40044.0, units='lbm')\n",
+    "prob.set_val(OAS_sys + 'fuel_reserve', 3000.0, units='lbm')\n",
+    "prob.set_val(OAS_sys + 'CD0', 0.0078, units='unitless')\n",
+    "prob.set_val(OAS_sys + 'cruise_Mach', 0.785, units='unitless')\n",
+    "prob.set_val(OAS_sys + 'cruise_altitude', 11303.682962301647, units='m')\n",
+    "prob.set_val(OAS_sys + 'cruise_range', 3500, units='nmi')\n",
+    "prob.set_val(OAS_sys + 'cruise_SFC', 0.53 / 3600, units='1/s')\n",
+    "prob.set_val(OAS_sys + 'engine_mass', 7400, units='lbm')\n",
+    "prob.set_val(OAS_sys + 'engine_location', np.array([25, -10.0, 0.0]), units='m')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d345e83d",
+   "metadata": {},
+   "source": [
+    "We are ready to run Aviary on this model. Note that there are multiple number of optimization loops in this run even though we have set `max_iter` to 0. This is because OpenAeroStruct has an optimization process internally. In order to shorten the runtime, we have set `run_driver = False`. This means that we will not run optimization but [run model](https://openmdao.org/newdocs/versions/latest/features/core_features/running_your_models/run_model.html). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b72253c8",
+   "metadata": {},
+   "source": [
+    "Finally, we print the newly computed wing mass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbb2078f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('wing mass = ',prob.model.get_val(av.Aircraft.Wing.MASS, units='lbm'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c04ddce7",
+   "metadata": {},
+   "source": [
+    "The result is comparitable to the output without OpenAeroStruct external subsystem."
    ]
   }
  ],

--- a/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
+++ b/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "from aviary.examples.external_subsystems.simple_weight.simple_weight_builder import WingWeightBuilder\n",
     "\n",
-    "\n",
+    "max_iter = 1\n",
     "phase_info = deepcopy(av.default_simple_phase_info)\n",
     "# Here we just add the simple weight system to only the pre-mission\n",
     "phase_info['pre_mission']['external_subsystems'] = [WingWeightBuilder(name=\"wing_external\")]\n",
@@ -74,7 +74,7 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\")\n",
+    "prob.add_driver(\"SLSQP\", max_iter)\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -112,6 +112,7 @@
     "# # Here we just add the simple weight system to only the pre-mission\n",
     "# phase_info['pre_mission']['external_subsystems'] = [WingWeightBuilder(name=\"wing_external\")]\n",
     "\n",
+    "max_iter = 1\n",
     "prob = av.AviaryProblem(av.default_simple_phase_info, mission_method=\"simple\", mass_method=\"FLOPS\")\n",
     "\n",
     "# Load aircraft and options data from user\n",
@@ -131,7 +132,7 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\")\n",
+    "prob.add_driver(\"SLSQP\", max_iter)\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -296,7 +297,8 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\")\n",
+    "max_iter = 1\n",
+    "prob.add_driver(\"SLSQP\", max_iter)\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -414,7 +416,7 @@
    "source": [
     "## Adding an OpenAeroStruct wingbox external subsystem\n",
     "\n",
-    "[OpenAeroStruct](https://github.com/mdolab/OpenAerostruct/) (OAS) is a lightweight tool that performs aerostructural optimization using OpenMDAO."
+    "[OpenAeroStruct](https://github.com/mdolab/OpenAerostruct/) (OAS) is a lightweight tool that performs aerostructural optimization using OpenMDAO. This is an example that shows you how to use an existing external package with Aviary."
    ]
   },
   {
@@ -466,6 +468,282 @@
     "\n",
     "Windows users should visit [OpenVSP](http://openvsp.org/download.php) and follow the instruction there."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3eb10495",
+   "metadata": {},
+   "source": [
+    "### Understanding the OpenAeroStruct Example\n",
+    "\n",
+    "The OpenAeroStruct example is explained in detail in [Using Aviary and OpenAeroStruct Together](../examples/OAS_subsystem)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9d285b7",
+   "metadata": {},
+   "source": [
+    "### Running the OpenAeroStruct Example\n",
+    "\n",
+    "We are ready to run this example. First, we build an `OAStructures`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e4482ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import openmdao.api as om\n",
+    "import aviary.api as av\n",
+    "from aviary.examples.external_subsystems.OAS_weight.OAS_wing_weight_builder import OASWingWeightBuilder\n",
+    "\n",
+    "wing_weight_builder = OASWingWeightBuilder()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f657b61",
+   "metadata": {},
+   "source": [
+    "Let's add a few phases in the mission. In particular, let's add `OAStructures` external subsystem to `pre_mission`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d779a398",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the phase_info and other common setup tasks\n",
+    "phase_info = {\n",
+    "    'climb_1': {\n",
+    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
+    "        'user_options': {\n",
+    "            'optimize_mach': False,\n",
+    "            'optimize_altitude': False,\n",
+    "            'polynomial_control_order': 1,\n",
+    "            'num_segments': 5,\n",
+    "            'order': 3,\n",
+    "            'solve_for_range': False,\n",
+    "            'initial_mach': (0.2, 'unitless'),\n",
+    "            'final_mach': (0.72, 'unitless'),\n",
+    "            'mach_bounds': ((0.18, 0.74), 'unitless'),\n",
+    "            'initial_altitude': (0.0, 'ft'),\n",
+    "            'final_altitude': (32000.0, 'ft'),\n",
+    "            'altitude_bounds': ((0.0, 34000.0), 'ft'),\n",
+    "            'throttle_enforcement': 'path_constraint',\n",
+    "            'fix_initial': True,\n",
+    "            'constrain_final': False,\n",
+    "            'fix_duration': False,\n",
+    "            'initial_bounds': ((0.0, 0.0), 'min'),\n",
+    "            'duration_bounds': ((64.0, 192.0), 'min'),\n",
+    "        },\n",
+    "        'initial_guesses': {'times': ([0, 128], 'min')},\n",
+    "    },\n",
+    "    'climb_2': {\n",
+    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
+    "        'user_options': {\n",
+    "            'optimize_mach': False,\n",
+    "            'optimize_altitude': False,\n",
+    "            'polynomial_control_order': 1,\n",
+    "            'num_segments': 5,\n",
+    "            'order': 3,\n",
+    "            'solve_for_range': False,\n",
+    "            'initial_mach': (0.72, 'unitless'),\n",
+    "            'final_mach': (0.72, 'unitless'),\n",
+    "            'mach_bounds': ((0.7, 0.74), 'unitless'),\n",
+    "            'initial_altitude': (32000.0, 'ft'),\n",
+    "            'final_altitude': (34000.0, 'ft'),\n",
+    "            'altitude_bounds': ((23000.0, 38000.0), 'ft'),\n",
+    "            'throttle_enforcement': 'boundary_constraint',\n",
+    "            'fix_initial': False,\n",
+    "            'constrain_final': False,\n",
+    "            'fix_duration': False,\n",
+    "            'initial_bounds': ((64.0, 192.0), 'min'),\n",
+    "            'duration_bounds': ((56.5, 169.5), 'min'),\n",
+    "        },\n",
+    "        'initial_guesses': {'times': ([128, 113], 'min')},\n",
+    "    },\n",
+    "    'descent_1': {\n",
+    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
+    "        'user_options': {\n",
+    "            'optimize_mach': False,\n",
+    "            'optimize_altitude': False,\n",
+    "            'polynomial_control_order': 1,\n",
+    "            'num_segments': 5,\n",
+    "            'order': 3,\n",
+    "            'solve_for_range': False,\n",
+    "            'initial_mach': (0.72, 'unitless'),\n",
+    "            'final_mach': (0.36, 'unitless'),\n",
+    "            'mach_bounds': ((0.34, 0.74), 'unitless'),\n",
+    "            'initial_altitude': (34000.0, 'ft'),\n",
+    "            'final_altitude': (500.0, 'ft'),\n",
+    "            'altitude_bounds': ((0.0, 38000.0), 'ft'),\n",
+    "            'throttle_enforcement': 'path_constraint',\n",
+    "            'fix_initial': False,\n",
+    "            'constrain_final': True,\n",
+    "            'fix_duration': False,\n",
+    "            'initial_bounds': ((120.5, 361.5), 'min'),\n",
+    "            'duration_bounds': ((29.0, 87.0), 'min'),\n",
+    "        },\n",
+    "        'initial_guesses': {'times': ([241, 58], 'min')},\n",
+    "    },\n",
+    "    'post_mission': {\n",
+    "        'include_landing': False,\n",
+    "        'constrain_range': True,\n",
+    "        'target_range': (1800., 'nmi'),\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "phase_info['pre_mission'] = {'include_takeoff': False, 'optimize_mass': True}\n",
+    "phase_info['pre_mission']['external_subsystems'] = [wing_weight_builder]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f1ce46e",
+   "metadata": {},
+   "source": [
+    "Start an Aviary problem, load in aircraft input deck and do routine input checks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bef599e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aircraft_definition_file = 'models/test_aircraft/aircraft_for_bench_FwFm.csv'\n",
+    "mission_method = 'simple'\n",
+    "mass_method = 'FLOPS'\n",
+    "make_plots = False\n",
+    "max_iter = 0\n",
+    "optimizer = 'SNOPT'\n",
+    "\n",
+    "prob = av.AviaryProblem(phase_info, mission_method=mission_method, mass_method='FLOPS')\n",
+    "\n",
+    "prob.load_inputs(aircraft_definition_file)\n",
+    "prob.check_inputs()\n",
+    "prob.add_pre_mission_systems()\n",
+    "prob.add_phases()\n",
+    "prob.add_post_mission_systems()\n",
+    "prob.link_phases()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0802ff94",
+   "metadata": {},
+   "source": [
+    "Next we select driver and setup the problem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4491a9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver = prob.driver = om.pyOptSparseDriver()\n",
+    "driver.options[\"optimizer\"] = optimizer\n",
+    "driver.declare_coloring()\n",
+    "driver.opt_settings[\"Major iterations limit\"] = max_iter\n",
+    "driver.opt_settings[\"Major optimality tolerance\"] = 1e-4\n",
+    "driver.opt_settings[\"Major feasibility tolerance\"] = 1e-5\n",
+    "driver.opt_settings[\"iSumm\"] = 6\n",
+    "\n",
+    "prob.add_design_variables()\n",
+    "prob.add_objective()\n",
+    "prob.setup()\n",
+    "prob.set_initial_guesses()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "354d81f3",
+   "metadata": {},
+   "source": [
+    "We need to set up OpenAeroStruct parameters before calling OpenAeroStruct:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d83c778",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OAS_sys = 'pre_mission.wing_weight.aerostructures.'\n",
+    "prob.set_val(OAS_sys + 'box_upper_x', np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'box_lower_x', np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'box_upper_y', np.array([ 0.0447,  0.046,  0.0472,  0.0484,  0.0495,  0.0505,  0.0514,  0.0523,  0.0531,  0.0538, 0.0545,  0.0551,  0.0557, 0.0563,  0.0568, 0.0573,  0.0577,  0.0581,  0.0585,  0.0588,  0.0591,  0.0593,  0.0595,  0.0597,  0.0599,  0.06,    0.0601,  0.0602,  0.0602,  0.0602,  0.0602,  0.0602,  0.0601,  0.06,    0.0599,  0.0598,  0.0596,  0.0594,  0.0592,  0.0589,  0.0586,  0.0583,  0.058,   0.0576,  0.0572,  0.0568,  0.0563,  0.0558,  0.0553,  0.0547,  0.0541]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'box_lower_y', np.array([-0.0447, -0.046, -0.0473, -0.0485, -0.0496, -0.0506, -0.0515, -0.0524, -0.0532, -0.054, -0.0547, -0.0554, -0.056, -0.0565, -0.057, -0.0575, -0.0579, -0.0583, -0.0586, -0.0589, -0.0592, -0.0594, -0.0595, -0.0596, -0.0597, -0.0598, -0.0598, -0.0598, -0.0598, -0.0597, -0.0596, -0.0594, -0.0592, -0.0589, -0.0586, -0.0582, -0.0578, -0.0573, -0.0567, -0.0561, -0.0554, -0.0546, -0.0538, -0.0529, -0.0519, -0.0509, -0.0497, -0.0485, -0.0472, -0.0458, -0.0444]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'twist_cp', np.array([-6., -6., -4., 0.]), units='deg')\n",
+    "prob.set_val(OAS_sys + 'spar_thickness_cp', np.array([0.004, 0.005, 0.008, 0.01]), units='m')\n",
+    "prob.set_val(OAS_sys + 'skin_thickness_cp', np.array([0.005, 0.01, 0.015, 0.025]), units='m')\n",
+    "prob.set_val(OAS_sys + 't_over_c_cp', np.array([0.08, 0.08, 0.10, 0.08]), units='unitless')\n",
+    "prob.set_val(OAS_sys + 'airfoil_t_over_c', 0.12, units='unitless')\n",
+    "prob.set_val(OAS_sys + 'fuel', 40044.0, units='lbm')\n",
+    "prob.set_val(OAS_sys + 'fuel_reserve', 3000.0, units='lbm')\n",
+    "prob.set_val(OAS_sys + 'CD0', 0.0078, units='unitless')\n",
+    "prob.set_val(OAS_sys + 'cruise_Mach', 0.785, units='unitless')\n",
+    "prob.set_val(OAS_sys + 'cruise_altitude', 11303.682962301647, units='m')\n",
+    "prob.set_val(OAS_sys + 'cruise_range', 3500, units='nmi')\n",
+    "prob.set_val(OAS_sys + 'cruise_SFC', 0.53 / 3600, units='1/s')\n",
+    "prob.set_val(OAS_sys + 'engine_mass', 7400, units='lbm')\n",
+    "prob.set_val(OAS_sys + 'engine_location', np.array([25, -10.0, 0.0]), units='m')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d345e83d",
+   "metadata": {},
+   "source": [
+    "We are ready to run Aviary on this model. Note that there are multiple number of optimization loops in this run even though we have set `max_iter` to 0. This is because OpenAeroStruct has an optimization process internally. In order to shorten the runtime, we have set `run_driver = False`. This means that we will not run optimization but [run model](https://openmdao.org/newdocs/versions/latest/features/core_features/running_your_models/run_model.html). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c13ac08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prob.run_aviary_problem('oas_solution.db', run_driver=False, make_plots=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b72253c8",
+   "metadata": {},
+   "source": [
+    "Finally, we print the newly computed wing mass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbb2078f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('wing mass = ',prob.model.get_val(av.Aircraft.Wing.MASS, units='lbm'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c04ddce7",
+   "metadata": {},
+   "source": [
+    "The result is comparitable to the output without OpenAeroStruct external subsystem."
+   ]
   }
  ],
  "metadata": {
@@ -484,7 +762,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
+++ b/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "from aviary.examples.external_subsystems.simple_weight.simple_weight_builder import WingWeightBuilder\n",
     "\n",
-    "max_iter = 1\n",
+    "\n",
     "phase_info = deepcopy(av.default_simple_phase_info)\n",
     "# Here we just add the simple weight system to only the pre-mission\n",
     "phase_info['pre_mission']['external_subsystems'] = [WingWeightBuilder(name=\"wing_external\")]\n",
@@ -74,7 +74,7 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\", max_iter)\n",
+    "prob.add_driver(\"SLSQP\")\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -112,7 +112,6 @@
     "# # Here we just add the simple weight system to only the pre-mission\n",
     "# phase_info['pre_mission']['external_subsystems'] = [WingWeightBuilder(name=\"wing_external\")]\n",
     "\n",
-    "max_iter = 1\n",
     "prob = av.AviaryProblem(av.default_simple_phase_info, mission_method=\"simple\", mass_method=\"FLOPS\")\n",
     "\n",
     "# Load aircraft and options data from user\n",
@@ -132,7 +131,7 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "prob.add_driver(\"SLSQP\", max_iter)\n",
+    "prob.add_driver(\"SLSQP\")\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -297,8 +296,7 @@
     "# Link phases and variables\n",
     "prob.link_phases()\n",
     "\n",
-    "max_iter = 1\n",
-    "prob.add_driver(\"SLSQP\", max_iter)\n",
+    "prob.add_driver(\"SLSQP\")\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",
@@ -416,7 +414,7 @@
    "source": [
     "## Adding an OpenAeroStruct wingbox external subsystem\n",
     "\n",
-    "[OpenAeroStruct](https://github.com/mdolab/OpenAerostruct/) (OAS) is a lightweight tool that performs aerostructural optimization using OpenMDAO. This is an example that shows you how to use an existing external package with Aviary."
+    "[OpenAeroStruct](https://github.com/mdolab/OpenAerostruct/) (OAS) is a lightweight tool that performs aerostructural optimization using OpenMDAO."
    ]
   },
   {
@@ -468,282 +466,6 @@
     "\n",
     "Windows users should visit [OpenVSP](http://openvsp.org/download.php) and follow the instruction there."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3eb10495",
-   "metadata": {},
-   "source": [
-    "### Understanding the OpenAeroStruct Example\n",
-    "\n",
-    "The OpenAeroStruct example is explained in detail in [Using Aviary and OpenAeroStruct Together](../examples/OAS_subsystem)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a9d285b7",
-   "metadata": {},
-   "source": [
-    "### Running the OpenAeroStruct Example\n",
-    "\n",
-    "We are ready to run this example. First, we build an `OAStructures`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1e4482ac",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import openmdao.api as om\n",
-    "import aviary.api as av\n",
-    "from aviary.examples.external_subsystems.OAS_weight.OAS_wing_weight_builder import OASWingWeightBuilder\n",
-    "\n",
-    "wing_weight_builder = OASWingWeightBuilder()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3f657b61",
-   "metadata": {},
-   "source": [
-    "Let's add a few phases in the mission. In particular, let's add `OAStructures` external subsystem to `pre_mission`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d779a398",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Load the phase_info and other common setup tasks\n",
-    "phase_info = {\n",
-    "    'climb_1': {\n",
-    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
-    "        'user_options': {\n",
-    "            'optimize_mach': False,\n",
-    "            'optimize_altitude': False,\n",
-    "            'polynomial_control_order': 1,\n",
-    "            'num_segments': 5,\n",
-    "            'order': 3,\n",
-    "            'solve_for_range': False,\n",
-    "            'initial_mach': (0.2, 'unitless'),\n",
-    "            'final_mach': (0.72, 'unitless'),\n",
-    "            'mach_bounds': ((0.18, 0.74), 'unitless'),\n",
-    "            'initial_altitude': (0.0, 'ft'),\n",
-    "            'final_altitude': (32000.0, 'ft'),\n",
-    "            'altitude_bounds': ((0.0, 34000.0), 'ft'),\n",
-    "            'throttle_enforcement': 'path_constraint',\n",
-    "            'fix_initial': True,\n",
-    "            'constrain_final': False,\n",
-    "            'fix_duration': False,\n",
-    "            'initial_bounds': ((0.0, 0.0), 'min'),\n",
-    "            'duration_bounds': ((64.0, 192.0), 'min'),\n",
-    "        },\n",
-    "        'initial_guesses': {'times': ([0, 128], 'min')},\n",
-    "    },\n",
-    "    'climb_2': {\n",
-    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
-    "        'user_options': {\n",
-    "            'optimize_mach': False,\n",
-    "            'optimize_altitude': False,\n",
-    "            'polynomial_control_order': 1,\n",
-    "            'num_segments': 5,\n",
-    "            'order': 3,\n",
-    "            'solve_for_range': False,\n",
-    "            'initial_mach': (0.72, 'unitless'),\n",
-    "            'final_mach': (0.72, 'unitless'),\n",
-    "            'mach_bounds': ((0.7, 0.74), 'unitless'),\n",
-    "            'initial_altitude': (32000.0, 'ft'),\n",
-    "            'final_altitude': (34000.0, 'ft'),\n",
-    "            'altitude_bounds': ((23000.0, 38000.0), 'ft'),\n",
-    "            'throttle_enforcement': 'boundary_constraint',\n",
-    "            'fix_initial': False,\n",
-    "            'constrain_final': False,\n",
-    "            'fix_duration': False,\n",
-    "            'initial_bounds': ((64.0, 192.0), 'min'),\n",
-    "            'duration_bounds': ((56.5, 169.5), 'min'),\n",
-    "        },\n",
-    "        'initial_guesses': {'times': ([128, 113], 'min')},\n",
-    "    },\n",
-    "    'descent_1': {\n",
-    "        'subsystem_options': {'core_aerodynamics': {'method': 'computed'}},\n",
-    "        'user_options': {\n",
-    "            'optimize_mach': False,\n",
-    "            'optimize_altitude': False,\n",
-    "            'polynomial_control_order': 1,\n",
-    "            'num_segments': 5,\n",
-    "            'order': 3,\n",
-    "            'solve_for_range': False,\n",
-    "            'initial_mach': (0.72, 'unitless'),\n",
-    "            'final_mach': (0.36, 'unitless'),\n",
-    "            'mach_bounds': ((0.34, 0.74), 'unitless'),\n",
-    "            'initial_altitude': (34000.0, 'ft'),\n",
-    "            'final_altitude': (500.0, 'ft'),\n",
-    "            'altitude_bounds': ((0.0, 38000.0), 'ft'),\n",
-    "            'throttle_enforcement': 'path_constraint',\n",
-    "            'fix_initial': False,\n",
-    "            'constrain_final': True,\n",
-    "            'fix_duration': False,\n",
-    "            'initial_bounds': ((120.5, 361.5), 'min'),\n",
-    "            'duration_bounds': ((29.0, 87.0), 'min'),\n",
-    "        },\n",
-    "        'initial_guesses': {'times': ([241, 58], 'min')},\n",
-    "    },\n",
-    "    'post_mission': {\n",
-    "        'include_landing': False,\n",
-    "        'constrain_range': True,\n",
-    "        'target_range': (1800., 'nmi'),\n",
-    "    },\n",
-    "}\n",
-    "\n",
-    "phase_info['pre_mission'] = {'include_takeoff': False, 'optimize_mass': True}\n",
-    "phase_info['pre_mission']['external_subsystems'] = [wing_weight_builder]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0f1ce46e",
-   "metadata": {},
-   "source": [
-    "Start an Aviary problem, load in aircraft input deck and do routine input checks:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4bef599e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "aircraft_definition_file = 'models/test_aircraft/aircraft_for_bench_FwFm.csv'\n",
-    "mission_method = 'simple'\n",
-    "mass_method = 'FLOPS'\n",
-    "make_plots = False\n",
-    "max_iter = 0\n",
-    "optimizer = 'SNOPT'\n",
-    "\n",
-    "prob = av.AviaryProblem(phase_info, mission_method=mission_method, mass_method='FLOPS')\n",
-    "\n",
-    "prob.load_inputs(aircraft_definition_file)\n",
-    "prob.check_inputs()\n",
-    "prob.add_pre_mission_systems()\n",
-    "prob.add_phases()\n",
-    "prob.add_post_mission_systems()\n",
-    "prob.link_phases()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0802ff94",
-   "metadata": {},
-   "source": [
-    "Next we select driver and setup the problem:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b4491a9d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "driver = prob.driver = om.pyOptSparseDriver()\n",
-    "driver.options[\"optimizer\"] = optimizer\n",
-    "driver.declare_coloring()\n",
-    "driver.opt_settings[\"Major iterations limit\"] = max_iter\n",
-    "driver.opt_settings[\"Major optimality tolerance\"] = 1e-4\n",
-    "driver.opt_settings[\"Major feasibility tolerance\"] = 1e-5\n",
-    "driver.opt_settings[\"iSumm\"] = 6\n",
-    "\n",
-    "prob.add_design_variables()\n",
-    "prob.add_objective()\n",
-    "prob.setup()\n",
-    "prob.set_initial_guesses()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "354d81f3",
-   "metadata": {},
-   "source": [
-    "We need to set up OpenAeroStruct parameters before calling OpenAeroStruct:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3d83c778",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "OAS_sys = 'pre_mission.wing_weight.aerostructures.'\n",
-    "prob.set_val(OAS_sys + 'box_upper_x', np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6]), units='unitless')\n",
-    "prob.set_val(OAS_sys + 'box_lower_x', np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6]), units='unitless')\n",
-    "prob.set_val(OAS_sys + 'box_upper_y', np.array([ 0.0447,  0.046,  0.0472,  0.0484,  0.0495,  0.0505,  0.0514,  0.0523,  0.0531,  0.0538, 0.0545,  0.0551,  0.0557, 0.0563,  0.0568, 0.0573,  0.0577,  0.0581,  0.0585,  0.0588,  0.0591,  0.0593,  0.0595,  0.0597,  0.0599,  0.06,    0.0601,  0.0602,  0.0602,  0.0602,  0.0602,  0.0602,  0.0601,  0.06,    0.0599,  0.0598,  0.0596,  0.0594,  0.0592,  0.0589,  0.0586,  0.0583,  0.058,   0.0576,  0.0572,  0.0568,  0.0563,  0.0558,  0.0553,  0.0547,  0.0541]), units='unitless')\n",
-    "prob.set_val(OAS_sys + 'box_lower_y', np.array([-0.0447, -0.046, -0.0473, -0.0485, -0.0496, -0.0506, -0.0515, -0.0524, -0.0532, -0.054, -0.0547, -0.0554, -0.056, -0.0565, -0.057, -0.0575, -0.0579, -0.0583, -0.0586, -0.0589, -0.0592, -0.0594, -0.0595, -0.0596, -0.0597, -0.0598, -0.0598, -0.0598, -0.0598, -0.0597, -0.0596, -0.0594, -0.0592, -0.0589, -0.0586, -0.0582, -0.0578, -0.0573, -0.0567, -0.0561, -0.0554, -0.0546, -0.0538, -0.0529, -0.0519, -0.0509, -0.0497, -0.0485, -0.0472, -0.0458, -0.0444]), units='unitless')\n",
-    "prob.set_val(OAS_sys + 'twist_cp', np.array([-6., -6., -4., 0.]), units='deg')\n",
-    "prob.set_val(OAS_sys + 'spar_thickness_cp', np.array([0.004, 0.005, 0.008, 0.01]), units='m')\n",
-    "prob.set_val(OAS_sys + 'skin_thickness_cp', np.array([0.005, 0.01, 0.015, 0.025]), units='m')\n",
-    "prob.set_val(OAS_sys + 't_over_c_cp', np.array([0.08, 0.08, 0.10, 0.08]), units='unitless')\n",
-    "prob.set_val(OAS_sys + 'airfoil_t_over_c', 0.12, units='unitless')\n",
-    "prob.set_val(OAS_sys + 'fuel', 40044.0, units='lbm')\n",
-    "prob.set_val(OAS_sys + 'fuel_reserve', 3000.0, units='lbm')\n",
-    "prob.set_val(OAS_sys + 'CD0', 0.0078, units='unitless')\n",
-    "prob.set_val(OAS_sys + 'cruise_Mach', 0.785, units='unitless')\n",
-    "prob.set_val(OAS_sys + 'cruise_altitude', 11303.682962301647, units='m')\n",
-    "prob.set_val(OAS_sys + 'cruise_range', 3500, units='nmi')\n",
-    "prob.set_val(OAS_sys + 'cruise_SFC', 0.53 / 3600, units='1/s')\n",
-    "prob.set_val(OAS_sys + 'engine_mass', 7400, units='lbm')\n",
-    "prob.set_val(OAS_sys + 'engine_location', np.array([25, -10.0, 0.0]), units='m')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d345e83d",
-   "metadata": {},
-   "source": [
-    "We are ready to run Aviary on this model. Note that there are multiple number of optimization loops in this run even though we have set `max_iter` to 0. This is because OpenAeroStruct has an optimization process internally. In order to shorten the runtime, we have set `run_driver = False`. This means that we will not run optimization but [run model](https://openmdao.org/newdocs/versions/latest/features/core_features/running_your_models/run_model.html). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5c13ac08",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prob.run_aviary_problem('oas_solution.db', run_driver=False, make_plots=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b72253c8",
-   "metadata": {},
-   "source": [
-    "Finally, we print the newly computed wing mass:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dbb2078f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print('wing mass = ',prob.model.get_val(av.Aircraft.Wing.MASS, units='lbm'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c04ddce7",
-   "metadata": {},
-   "source": [
-    "The result is comparitable to the output without OpenAeroStruct external subsystem."
-   ]
   }
  ],
  "metadata": {
@@ -762,7 +484,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,

--- a/aviary/docs/getting_started/onboarding_level2.ipynb
+++ b/aviary/docs/getting_started/onboarding_level2.ipynb
@@ -87,7 +87,7 @@
     "optimizer = \"IPOPT\"\n",
     "analysis_scheme = av.AnalysisScheme.COLLOCATION\n",
     "objective_type = None\n",
-    "record_filename = 'bench2_history.db'\n",
+    "record_filename = 'aviary_history.db'\n",
     "restart_filename = None\n",
     "max_iter = 0\n",
     "\n",
@@ -811,7 +811,7 @@
    "outputs": [],
    "source": [
     "objective_type = \"hybrid_objective\"\n",
-    "record_filename = 'bench2_history.db'\n",
+    "record_filename = 'aviary_history.db'\n",
     "restart_filename = None\n",
     "max_iter = 1"
    ]
@@ -939,7 +939,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -2264,7 +2264,7 @@ class AviaryProblem(om.Problem):
             warnings.filterwarnings('ignore', category=UserWarning)
             failed = self.run_model()
             warnings.filterwarnings('default', category=UserWarning)
-            final_range_nmi = self.get_val('traj.distance_final', units='NM')[0]
+            # final_range_nmi = self.get_val('traj.distance_final', units='NM')[0]
 
         if self.aviary_inputs.get_val('debug_mode'):
             with open('output_list.txt', 'w') as outfile:

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -2264,7 +2264,7 @@ class AviaryProblem(om.Problem):
             warnings.filterwarnings('ignore', category=UserWarning)
             failed = self.run_model()
             warnings.filterwarnings('default', category=UserWarning)
-            # final_range_nmi = self.get_val('traj.distance_final', units='NM')[0]
+            final_range_nmi = self.get_val('traj.distance_final', units='NM')[0]
 
         if self.aviary_inputs.get_val('debug_mode'):
             with open('output_list.txt', 'w') as outfile:

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -2273,7 +2273,6 @@ class AviaryProblem(om.Problem):
             warnings.filterwarnings('ignore', category=UserWarning)
             failed = self.run_model()
             warnings.filterwarnings('default', category=UserWarning)
-            # final_range_nmi = self.get_val('traj.distance_final', units='NM')[0]
 
         if self.aviary_inputs.get_val('debug_mode'):
             with open('output_list.txt', 'w') as outfile:


### PR DESCRIPTION
### Summary

- Finished writing the OAS example in `onboarding_ext_subsystem.ipynb`. Have to use `run_model` instead of `run_driver` because OAS runtime exceeded the maximum allowed. 
- In `methods_for_level2.py`, the variable `final_range_nmi` is commented out because it is never used and will cause error when `run_model`. 
- In `onboarding_level2.ipynb`, replaced `bench2_history.db` by `aviary_history.db`.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None