### PR TITLE
Add CSS file for dashboard to package_data. Also mod the no dev install workflow to test package

### DIFF
--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -85,6 +85,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "============================================================="
-          echo "Run Tests"
+          echo "Run Tests (from directory other than repo root)"
           echo "============================================================="
-          testflo . -n 1 --show_skipped
+          cd $HOME
+          testflo aviary -n 1 --show_skipped --timeout=240 --durations=20

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             "models/large_single_aisle_2/*",
             "models/small_single_aisle/*",
             "models/test_aircraft/*",
+            "visualization/assets/*",
             "visualization/assets/aviary_vars/*"
         ],
         f"{pkgname}.subsystems.aero.test.data": ["*.csv"],


### PR DESCRIPTION
### Summary

1. The setup.py file package_data variables did not include the directory with the CSS file for the dashboard. Added
3. The no dev install workflow was testing the code in the repo, not the package that was installed into site-packages. Modified the github workflow

### Related Issues

- Resolves #39 and #27 

### Backwards incompatibilities

None

### New Dependencies

None