### PR TITLE
fix bug in subsytem tester

### DIFF
--- a/aviary/subsystems/test/subsystem_tester.py
+++ b/aviary/subsystems/test/subsystem_tester.py
@@ -23,7 +23,10 @@ class TestSubsystemBuilderBase(unittest.TestCase):
         '''
         try:
             package, method = path_to_builder.rsplit('.', 1)
-            module = import_module(package, base_package)
+            package_path, package_name = package.rsplit('.', 1)
+            module_path = '.'.join([path_to_builder, package_path]) if package_path \
+                else path_to_builder
+            module = import_module(package_name, module_path)
             builder = getattr(module, method)
         except ImportError:
             builder = 'Skipping due to missing dependencies'

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
             "visualization/assets/*",
             "visualization/assets/aviary_vars/*"
         ],
-        'aviary.docs': ['*.py',
+        f"{pkgname}.docs": ['*.py',
                         'tests/*.py',
                         '*/*.md',
                         '*/*.ipynb',


### PR DESCRIPTION
### Summary

I encountered this bug in parsing the module path in `subsystem_tester` while messing with the battery stuff:

```
package='battery.battery_builder' method='BatteryBuilder'
test_battery_builder.py:TestBattery.test_check_design_variables  ... SKIP (00:00:0.00, 190 MB)
Skipping due to missing dependencies: No module named 'battery'
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None