### PR TITLE
Updated workflows to use the conda-forge channel and to facilitate use for testing

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -11,6 +11,9 @@ on:
   merge_group:
     branches: [ main ]
 
+  # Allow running the workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
 
   pre_commit:

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.PY }}
+          channels: conda-forge
 
       - name: Install dependencies
         shell: bash -l {0}
@@ -232,7 +233,7 @@ jobs:
           echo "Build the docs"
           echo "============================================================="
           bash build_book.sh
-          
+
       - name: Display doc build reports
         continue-on-error: True
         if: matrix.MAKE_DOCS

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -17,7 +17,6 @@ on:
 jobs:
 
   pre_commit:
-    if: github.repository_owner == 'OpenMDAO'
     # run pre-commit checks
     runs-on: ubuntu-latest
 
@@ -29,7 +28,6 @@ jobs:
     - uses: pre-commit/action@v3.0.0
 
   test_ubuntu:
-    if: github.repository_owner == 'OpenMDAO'
     runs-on: ubuntu-latest
 
     timeout-minutes: 90

--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -11,6 +11,9 @@ on:
   merge_group:
     branches: [ main ]
 
+  # Allow running the workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
 
   test_ubuntu_no_dev_install:

--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.PY }}
+          channels: conda-forge
 
       - name: Checkout Aviary
         uses: actions/checkout@v2

--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -17,7 +17,6 @@ on:
 jobs:
 
   test_ubuntu_no_dev_install:
-    if: github.repository_owner == 'OpenMDAO'
     runs-on: ubuntu-latest
 
     timeout-minutes: 90


### PR DESCRIPTION
### Summary

Made the following changes to the GitHub workflows:

- removed the `github.repository_owner == 'OpenMDAO'` requirement, since the repo is public now and Actions is free
- add the `workflow_dispatch` trigger so workflows can be run on demand
- restricted miniconda to use just the `conda-forge` channel to avoid running afoul of Anaconda licensing
 
### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None